### PR TITLE
WIDY-104 Truncate long task titles

### DIFF
--- a/src/components/eod/Board/PlanTask/PlanTask.jsx
+++ b/src/components/eod/Board/PlanTask/PlanTask.jsx
@@ -13,15 +13,28 @@ const Actions = styled.div`
   }
 `;
 
-const Title = styled.div`
+const StyledIconRightThickArrow = styled(IconRightThickArrow)`
+  flex-shrink: 0;
+`;
+
+const TitleContainer = styled.div`
   display: flex;
   align-items: center;
+  flex: 1;
+`;
+
+const Title = styled.span`
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin-right: 16px;
+  flex: 1;
+  width: 0;
 `;
 
 const StyledPlanTask = styled.div`
   display: flex;
   align-items: center;
-  justify-content: space-between;
   flex-direction: row;
   border: none;
   background: ${props => (props.isDragging || props.selected ? props.theme.neutral050 : 'white')};
@@ -101,10 +114,10 @@ class PlanTask extends Component {
               onClick={this.handleTaskClick}
               isDragging={snapshot.isDragging}
             >
-              <Title onDoubleClick={this.handleTaskDoubleClick}>
-                <IconRightThickArrow />
-                <span className="title">{children}</span>
-              </Title>
+              <TitleContainer onDoubleClick={this.handleTaskDoubleClick}>
+                <StyledIconRightThickArrow />
+                <Title>{children}</Title>
+              </TitleContainer>
               <Actions>
                 <IconLaunch onClick={this.handleLaunchClick} />
                 <IconEdit

--- a/src/components/eod/Board/Task/Task.jsx
+++ b/src/components/eod/Board/Task/Task.jsx
@@ -79,6 +79,11 @@ const StyledTask = styled.div`
 
 const TaskName = styled.span`
   flex: 1;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  width: 0;
+  margin-right: 16px;
 `;
 
 const Controls = styled.div`


### PR DESCRIPTION
# WIDY Frontend

## Overview

Ticket [WIDY-104](https://jcmnunes.atlassian.net/browse/WIDY-104)

Use the ellipsis strategy to deal with long task names.

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bugfix (non-breaking change which adds functionality)
- [ ] Hotfix (fix for code currently broken in production)
