### PR TITLE
WIDY-96 Plan illustration only when there are no tasks

### DIFF
--- a/src/components/Dialogs/DeleteTask/DeleteTask.jsx
+++ b/src/components/Dialogs/DeleteTask/DeleteTask.jsx
@@ -4,9 +4,9 @@ import { Dialog } from '../../UI';
 
 const DeleteTask = props => {
   const deleteAction = () => {
-    const { sectionId, taskId } = props;
+    const { taskId, sectionId } = props;
     props.storeSelectedSectionId(sectionId);
-    props.storeSelectedTaskId(taskId);
+    props.storeSelectedTaskId('');
     props.deleteTask(taskId);
   };
 

--- a/src/components/UI/Button/Button.jsx
+++ b/src/components/UI/Button/Button.jsx
@@ -170,7 +170,8 @@ const Button = ({
   children,
   ...other
 }) => {
-  const handleClick = () => {
+  const handleClick = e => {
+    e.stopPropagation();
     if (!onClick) return;
     onClick();
   };

--- a/src/components/eod/Board/Section/Section.jsx
+++ b/src/components/eod/Board/Section/Section.jsx
@@ -23,7 +23,7 @@ const EmptyTasks = styled.div`
   justify-content: center;
   border: 1px solid ${props => props.theme.neutral100};
   border-radius: 4px;
-  height: ${props => (props.isPlan ? '275px' : '96px')};
+  height: ${props => (props.isPlan && props.noTasks ? '275px' : '96px')};
   background-color: ${props => (props.isDraggingOver ? props.theme.neutral050 : 'white')};
   transition: background-color 0.2s ease;
   font-size: 16px;
@@ -78,7 +78,8 @@ class Section extends Component {
   };
 
   renderEmptySection = (provided, snapshot) => {
-    const { section } = this.props;
+    const { section, tasks } = this.props;
+    const noTasks = Object.keys(tasks).length === 0;
     return (
       <EmptyTasks
         ref={provided.innerRef}
@@ -86,11 +87,16 @@ class Section extends Component {
         isDraggingOver={snapshot.isDraggingOver}
         isPlan={section.isPlan}
         onClick={this.openModal}
+        noTasks={noTasks}
       >
         {section.isPlan && (
           <>
-            <IllustrationPlan />
-            <span>Start by adding tasks here to plan your day.</span>
+            {noTasks && <IllustrationPlan />}
+            {noTasks ? (
+              <span>Start by adding tasks here to plan your day.</span>
+            ) : (
+              <span>No tasks in Plan.</span>
+            )}
           </>
         )}
         {!section.isPlan &&

--- a/src/reducers/tasks/tasksReducer.js
+++ b/src/reducers/tasks/tasksReducer.js
@@ -60,6 +60,13 @@ export default (state = initialState, action) => {
           },
         },
       };
+    case types.DELETE_TASK_REQUEST: {
+      const { [action.taskId]: val, ...newTasksById } = state.byId;
+      return {
+        ...state,
+        byId: newTasksById,
+      };
+    }
     default:
       return state;
   }


### PR DESCRIPTION
# WIDY Frontend

## Overview

Ticket [WIDY-96](https://jcmnunes.atlassian.net/browse/WIDY-96)

The plan illustration is visible just when there are no tasks
Removing a task should also delete it from `tasksById`

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bugfix (non-breaking change which adds functionality)
- [ ] Hotfix (fix for code currently broken in production)
