### PR TITLE
WIDY-129 Improve perf of Section component

### DIFF
--- a/src/components/eod/Board/PlanTask/PlanTask.container.js
+++ b/src/components/eod/Board/PlanTask/PlanTask.container.js
@@ -5,8 +5,9 @@ import { openModal } from '../../../../actions/modals';
 import { storeSelectedSectionId } from '../../../../actions/sections';
 import { storeSelectedTaskId } from '../../../../actions/tasks';
 
-const mapStateToProps = state => ({
+const mapStateToProps = (state, ownProps) => ({
   selectedTaskId: state.tasks.selected,
+  taskTitle: state.tasks.byId[ownProps.taskId].title,
 });
 
 export default connect(

--- a/src/components/eod/Board/PlanTask/PlanTask.jsx
+++ b/src/components/eod/Board/PlanTask/PlanTask.jsx
@@ -130,7 +130,7 @@ class PlanTask extends Component {
   };
 
   render() {
-    const { taskId, sectionId, selectedTaskId, index, theme, children } = this.props;
+    const { taskId, sectionId, selectedTaskId, index, theme, taskTitle } = this.props;
     const { showDeleteTaskDialog, duplicate, launch, edit, trash } = this.state;
     return (
       <>
@@ -146,11 +146,11 @@ class PlanTask extends Component {
             >
               <TitleContainer onDoubleClick={this.handleTaskDoubleClick}>
                 <StyledIconRightThickArrow />
-                <Title>{children}</Title>
+                <Title>{taskTitle}</Title>
               </TitleContainer>
               <Actions>
                 <CopyToClipboard
-                  text={children}
+                  text={taskTitle}
                   onCopy={() =>
                     toast.success({
                       title: 'Success',
@@ -210,7 +210,7 @@ PlanTask.propTypes = {
   sectionId: PropTypes.string.isRequired,
   taskId: PropTypes.string.isRequired,
   selectedTaskId: PropTypes.string.isRequired,
-  children: PropTypes.string.isRequired,
+  taskTitle: PropTypes.string.isRequired,
   storeSelectedTaskId: PropTypes.func.isRequired,
   storeSelectedSectionId: PropTypes.func.isRequired,
   openSidebar: PropTypes.func.isRequired,

--- a/src/components/eod/Board/Section/Section.container.js
+++ b/src/components/eod/Board/Section/Section.container.js
@@ -2,10 +2,11 @@ import { connect } from 'react-redux';
 import Section from './Section';
 import { openModal } from '../../../../actions/modals';
 import { storeCreateTaskData } from '../../../../actions/tasks';
+import { noTasksSelector } from '../../../../selectors/tasks/tasksSelectors';
 
 const mapStateToProps = (state, props) => ({
   section: state.sections.byId[props.sectionId],
-  tasks: state.tasks.byId,
+  noTasks: noTasksSelector(state),
 });
 
 export default connect(

--- a/src/components/eod/Board/Section/Section.jsx
+++ b/src/components/eod/Board/Section/Section.jsx
@@ -55,22 +55,14 @@ class Section extends Component {
   };
 
   renderSection = provided => {
-    const { section, tasks } = this.props;
+    const { section } = this.props;
     return (
       <Tasks ref={provided.innerRef} {...provided.droppableProps}>
         {section.tasks.map((taskId, index) => {
           if (section.isPlan) {
-            return (
-              <PlanTask key={taskId} taskId={taskId} index={index} sectionId={section.id}>
-                {tasks[taskId].title}
-              </PlanTask>
-            );
+            return <PlanTask key={taskId} taskId={taskId} index={index} sectionId={section.id} />;
           }
-          return (
-            <Task key={taskId} taskId={taskId} index={index} sectionId={section.id}>
-              {tasks[taskId].title}
-            </Task>
-          );
+          return <Task key={taskId} taskId={taskId} index={index} sectionId={section.id} />;
         })}
         {provided.placeholder}
       </Tasks>
@@ -78,8 +70,7 @@ class Section extends Component {
   };
 
   renderEmptySection = (provided, snapshot) => {
-    const { section, tasks } = this.props;
-    const noTasks = Object.keys(tasks).length === 0;
+    const { section, noTasks } = this.props;
     return (
       <EmptyTasks
         ref={provided.innerRef}
@@ -138,9 +129,7 @@ Section.propTypes = {
     tasks: PropTypes.array,
     title: PropTypes.string,
   }).isRequired,
-  tasks: PropTypes.shape({
-    [PropTypes.string]: PropTypes.object,
-  }).isRequired,
+  noTasks: PropTypes.bool.isRequired,
 };
 
 export default Section;

--- a/src/components/eod/Board/Task/DraggableTask.jsx
+++ b/src/components/eod/Board/Task/DraggableTask.jsx
@@ -41,7 +41,7 @@ class DraggableTask extends Component {
       activeTask,
       index,
       isCompleted,
-      children,
+      taskTitle,
     } = this.props;
     return (
       <Draggable draggableId={taskId} index={index}>
@@ -65,7 +65,7 @@ class DraggableTask extends Component {
             openModal={this.props.openModal}
             isDragging={snapshot.isDragging}
           >
-            {children}
+            {taskTitle}
           </Task>
         )}
       </Draggable>
@@ -83,7 +83,7 @@ DraggableTask.propTypes = {
     inBreak: PropTypes.bool.isRequired,
   }).isRequired,
   isCompleted: PropTypes.bool.isRequired,
-  children: PropTypes.string.isRequired,
+  taskTitle: PropTypes.string.isRequired,
   storeSelectedTaskId: PropTypes.func.isRequired,
   storeSelectedSectionId: PropTypes.func.isRequired,
   openSidebar: PropTypes.func.isRequired,

--- a/src/components/eod/Board/Task/Task.container.js
+++ b/src/components/eod/Board/Task/Task.container.js
@@ -9,6 +9,7 @@ const mapStateToProps = (state, ownProps) => ({
   selectedTaskId: state.tasks.selected,
   activeTask: state.activeTask,
   isCompleted: state.tasks.byId[ownProps.taskId].completed,
+  taskTitle: state.tasks.byId[ownProps.taskId].title,
 });
 
 export default connect(

--- a/src/components/eod/EOD.jsx
+++ b/src/components/eod/EOD.jsx
@@ -9,7 +9,6 @@ import Sidebar from './Sidebar';
 import ActiveTaskPopup from './ActiveTaskPopup';
 import { getCurrentPomodoroInfo } from '../../helpers/pomodoro';
 import settings from '../../helpers/settings';
-import NoDays from './NoDays';
 
 const { pomodoro } = settings();
 

--- a/src/selectors/tasks/tasksSelectors.js
+++ b/src/selectors/tasks/tasksSelectors.js
@@ -28,3 +28,8 @@ export const isSelectedTaskInPlanSelector = createSelector(
     return false;
   },
 );
+
+export const noTasksSelector = createSelector(
+  tasksByIdSelector,
+  tasksById => Object.keys(tasksById).length === 0,
+);


### PR DESCRIPTION
# WIDY Frontend

## Overview

Ticket [WIDY-129](https://jcmnunes.atlassian.net/browse/WIDY-129)

- Sections do not have `tasks.byId` as prop anymore
- Remove unused import from EOD component

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bugfix (non-breaking change which adds functionality)
- [ ] Hotfix (fix for code currently broken in production)
- [x] Task
