### PR TITLE
WIDY-135 Use activeTask heartbeat to update Pomodoro time

### DIFF
--- a/src/components/UI/EditableInput/EditableInput.jsx
+++ b/src/components/UI/EditableInput/EditableInput.jsx
@@ -79,7 +79,7 @@ class EditableInput extends Component {
 
   render() {
     const { editing, value } = this.state;
-    const { initialValue, ...other } = this.props;
+    const { initialValue, action, ...other } = this.props;
     return (
       <StyledEditableInput
         onSubmit={this.handleSubmit}

--- a/src/components/eod/ActiveTaskPopup/ActiveTaskPopup.jsx
+++ b/src/components/eod/ActiveTaskPopup/ActiveTaskPopup.jsx
@@ -101,6 +101,7 @@ const ActiveTaskPopup = ({
         onCheckClick={handleCheckClick}
         onCheckChange={handleCheckChange}
         isDragging={false}
+        isInActiveTaskPopup
         data-test="task"
       >
         {activeTask.title}

--- a/src/components/eod/Board/Task/Task.jsx
+++ b/src/components/eod/Board/Task/Task.jsx
@@ -144,6 +144,7 @@ const Task = ({
   storeSelectedTaskId,
   openModal,
   isDragging,
+  isInActiveTaskPopup,
   children,
   ...other
 }) => (
@@ -160,7 +161,7 @@ const Task = ({
   >
     <Checkbox checked={isCompleted} onChange={onCheckChange} onClick={onCheckClick} />
     <TaskTitle onDoubleClick={onDoubleClick}>{children}</TaskTitle>
-    <StyledCopyButton taskTitle={children} />
+    {!isInActiveTaskPopup && <StyledCopyButton taskTitle={children} />}
     {renderControls && !isCompleted && (
       <Controls>
         <Timer taskId={taskId} sectionId={sectionId} />
@@ -181,6 +182,7 @@ const Task = ({
 Task.defaultProps = {
   taskRef: null,
   renderControls: true,
+  isInActiveTaskPopup: false,
   onClick: noop,
   onDoubleClick: noop,
   onCheckChange: noop,
@@ -208,6 +210,7 @@ Task.propTypes = {
   storeSelectedSectionId: PropTypes.func,
   openModal: PropTypes.func,
   isDragging: PropTypes.bool.isRequired,
+  isInActiveTaskPopup: PropTypes.bool,
 };
 
 export default Task;

--- a/src/components/eod/Pomodoro/Pomodoro.container.js
+++ b/src/components/eod/Pomodoro/Pomodoro.container.js
@@ -5,6 +5,7 @@ const mapStateToProps = state => ({
   taskId: state.tasks.selected,
   sectionId: state.sections.selected,
   isTaskActive: state.tasks.selected === state.activeTask.taskId,
+  activeTask: state.activeTask,
   selectedTask: state.tasks.selected ? state.tasks.byId[state.tasks.selected] : {},
 });
 

--- a/src/components/eod/Pomodoro/Pomodoro.jsx
+++ b/src/components/eod/Pomodoro/Pomodoro.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import styled, { withTheme } from 'styled-components';
 import moment from 'moment';
@@ -30,43 +30,15 @@ const Units = styled.div`
   margin-left: 4px;
 `;
 
-// TODO 👇
-let timer = null;
-
-const Pomodoro = ({ taskId, sectionId, isTaskActive, selectedTask }) => {
-  const [time, setTime] = useState(0);
-
-  /**
-   * Responsible for updating the Pomodoro widget
-   */
-  useEffect(() => {
-    if (timer) {
-      clearInterval(timer);
-      timer = null;
-    }
-    if (isTaskActive) {
-      setTime(selectedTask.time + moment().diff(selectedTask.start, 'seconds'));
-      timer = setInterval(() => {
-        setTime(prevTime => prevTime + 1);
-      }, 1000);
-    } else {
-      setTime(selectedTask.time);
-    }
-    return () => clearInterval(timer);
-  }, [taskId, isTaskActive]);
-
-  const { inBreak, elapsedTime } = getCurrentPomodoroInfo(time);
+const Pomodoro = ({ taskId, sectionId, isTaskActive, activeTask, selectedTask }) => {
+  const { time, start } = activeTask;
+  const newTime = isTaskActive > 0 ? time + moment().diff(start, 'seconds') : selectedTask.time;
 
   const renderTime = () => {
-    if (inBreak) {
-      return `${elapsedTime} / ${pomodoro.shortBreak}`;
-    }
+    const { inBreak, elapsedTime } = getCurrentPomodoroInfo(newTime);
+    if (inBreak) return `${elapsedTime} / ${pomodoro.shortBreak}`;
     return `${elapsedTime} / ${pomodoro.length}`;
   };
-
-  // TODO ➜ remove these console.logs
-  // console.log('Task title:', selectedTask.title);
-  // console.log('time:', time);
 
   return (
     <>
@@ -79,7 +51,7 @@ const Pomodoro = ({ taskId, sectionId, isTaskActive, selectedTask }) => {
           </Time>
         </StyledPomodoro>
       )}
-      <Stats time={time} />
+      <Stats time={newTime} />
     </>
   );
 };
@@ -88,6 +60,13 @@ Pomodoro.propTypes = {
   taskId: PropTypes.string.isRequired,
   sectionId: PropTypes.string.isRequired,
   isTaskActive: PropTypes.bool.isRequired,
+  activeTask: PropTypes.shape({
+    taskId: PropTypes.string.isRequired,
+    title: PropTypes.string.isRequired,
+    sectionId: PropTypes.string.isRequired,
+    dayId: PropTypes.string.isRequired,
+    inBreak: PropTypes.bool.isRequired,
+  }).isRequired,
   selectedTask: PropTypes.shape({
     time: PropTypes.number.isRequired,
     start: PropTypes.string,

--- a/src/helpers/pomodoro.js
+++ b/src/helpers/pomodoro.js
@@ -17,6 +17,7 @@ export const getNumberOfPomodoros = time => {
 };
 
 /**
+ * Returns information about current active task time
  *
  * @param {number} time - Elapsed time (secs)
  * @returns {{ inBreak: boolean, elapsedTime: string }}
@@ -36,6 +37,17 @@ export const getCurrentPomodoroInfo = time => {
   return info;
 };
 
+/**
+ * Formats total time
+ *
+ * @example
+ *   getTotalTime(4 * 60) ➜ { hours: 0, minutes: 4 }
+ *   getTotalTime(64 * 60) ➜ { hours: 1, minutes: 4 }
+ *
+ * @param {number} time - Time in secs
+ * @returns {{ hours: number, minutes: number }} - Object containing two integers representing
+ * time in hours and minutes
+ */
 export const getTotalTime = time => {
   const hours = time / 60 / 60;
 
@@ -45,6 +57,12 @@ export const getTotalTime = time => {
   };
 };
 
+/**
+ * Converts time in secs to a formatted string (00 : 00)
+ *
+ * @param {number} time - Time to format (secs)
+ * @returns {string} - Formatted time ➜ 00 : 00
+ */
 export const formatTime = time => {
   const mins = Math.floor(time);
   const secs = Math.round((time - Math.floor(time)) * 60);


### PR DESCRIPTION
# WIDY Frontend

## Overview

[WIDY-135](https://jcmnunes.atlassian.net/browse/WIDY-135)

Use activeTask heartbeat to update Pomodoro time

**Other changes**:
- Fix warning regarding extraneous prop (EditableInput)
- Improve JSDocs of Pomodoro helpers
- Hide copy button in ActiveTaskPopup

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bugfix (non-breaking change which adds functionality)
- [ ] Hotfix (fix for code currently broken in production)
