### PR TITLE
WIDY-132 Remove left padding of table rows (Stats)

### DIFF
--- a/src/components/eod/Pomodoro/Stats/Stats.jsx
+++ b/src/components/eod/Pomodoro/Stats/Stats.jsx
@@ -10,7 +10,7 @@ const StyledStats = styled.table`
 `;
 
 const Td = styled.td`
-  padding: 8px;
+  padding: 8px 8px 8px 0;
   vertical-align: middle;
 `;
 


### PR DESCRIPTION
# WIDY Frontend

## Overview

[WIDY-132](https://jcmnunes.atlassian.net/browse/WIDY-132)

Remove left padding of table rows (Stats)

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bugfix (non-breaking change which adds functionality)
- [ ] Hotfix (fix for code currently broken in production)
