### PR TITLE
fix: Truncate text for large scope names

### DIFF
--- a/src/components/settings/Page/Scopes/ScopesTable/ScopesTable.jsx
+++ b/src/components/settings/Page/Scopes/ScopesTable/ScopesTable.jsx
@@ -19,7 +19,10 @@ const ScopeName = styled.span`
   display: inline-block;
   font-size: 16px;
   flex: 1;
-  margin-left: 12px;
+  margin: 0 12px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 `;
 
 const Row = styled.div`


### PR DESCRIPTION
WDY-251